### PR TITLE
2 add informative neighborhood   str   method for porchlightneighborhoodneighborhood

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -124,6 +124,20 @@ class BaseDoor:
 
         return False
 
+    def __repr__(self):
+        info = {
+            "name": self.name,
+            "base_function": self._base_function,
+            "arguments": self.arguments,
+            "return_vals": self.return_vals,
+        }
+
+        substrs = [f"{key}={value}" for key, value in info.items()]
+
+        outstr = f"BaseDoor({', '.join(substrs)})"
+
+        return outstr
+
     def _inspect_base_callable(self):
         """Inspect the BaseDoor's baseline callable for primary attributes.
 

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -41,6 +41,24 @@ class Neighborhood:
         self._params = {}
         self._call_order = []
 
+    def __repr__(self):
+        """Must communicate teh following:
+        + A unique identifier.
+        + List of doors
+        + list of tracked parameters and their values.
+        """
+        info = {
+            "doors": self.doors,
+            "params": self.params,
+            "call_order": self._call_order,
+        }
+
+        infostrs = [f"{key}={value}" for key, value in info.items()]
+
+        outstring = f"Neighborhood({', '.join(infostrs)})"
+
+        return outstring
+
     def add_function(
         self, function: Callable, overwrite_defaults: bool = False
     ):
@@ -94,7 +112,7 @@ class Neighborhood:
         self._call_order.append(new_door.name)
 
         # Update the parameters as necesssary.
-        # This will prefer default values passed by earlier
+        # This will prefer default values passed by earlier doors.
         for pname, ptype in new_door.arguments.items():
             if pname not in self._params or overwrite_defaults:
                 # This is a new parameter.

--- a/porchlight/param.py
+++ b/porchlight/param.py
@@ -60,7 +60,9 @@ class Param:
     # have easy access, so just hiding these behind properties.
     __slots__ = ["_name", "_value", "constant", "_type"]
 
-    def __init__(self, name: str, value: Any = Empty(), constant: bool = False):
+    def __init__(
+        self, name: str, value: Any = Empty(), constant: bool = False
+    ):
         """Initializes the Param object.
 
         Arguments
@@ -82,9 +84,18 @@ class Param:
         self.constant = constant
         self._type = type(self._value)
 
-    def __str__(self):
-        outstr = f"{self._name} ({self._type}): {self._value}"
-        outstr += "" if not self.constant else " (constant)"
+    def __repr__(self):
+        info = {
+            "name": self.name,
+            "value": self.value,
+            "constant": self.constant,
+            "type": self.type,
+        }
+
+        infostrings = [f"{key}={value}" for key, value in info.items()]
+
+        outstr = f"Param({', '.join(infostrings)})"
+
         return outstr
 
     def __eq__(self, other):

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -168,6 +168,22 @@ class TestBaseDoor(TestCase):
         self.assertFalse(fxn1 == fxn2)
         self.assertTrue(fxn1 == other_fxn1)
 
+    def test___repr__(self):
+        """Test the BaseDoor"""
+
+        def test(x: int) -> int:
+            y = x ** 2
+            return y
+
+        expected_repr = (
+            f"BaseDoor(name=test, base_function={str(test)}, "
+            f"arguments={{'x': <class 'int'>}}, "
+            f"return_vals=[['y']])"
+        )
+
+        test_door = BaseDoor(test)
+        self.assertEqual(repr(test_door), expected_repr)
+
     def test__inspect_base_callable(self):
         def bigfxn(x, y, *, z=5):
             output = sum((x, y, z))

--- a/porchlight/tests/test_param.py
+++ b/porchlight/tests/test_param.py
@@ -52,14 +52,13 @@ class ParamTest(TestCase):
 
         self.assertNotEqual(param1, nonparam)
 
-    def test___str__(self):
-        outstr = str(param.Param("x", 1))
+    def test___repr__(self):
+        param1 = param.Param("x", 1)
+        expected_string = (
+            "Param(name=x, value=1, constant=False, " "type=<class 'int'>)"
+        )
 
-        self.assertEqual(outstr, "x (<class 'int'>): 1")
-
-        outstr = str(param.Param("exodia", "bing", True))
-
-        self.assertEqual(outstr, "exodia (<class 'str'>): bing (constant)")
+        self.assertEqual(repr(param1), expected_string)
 
     def test_properties(self):
         # Properties should not be directly mutable.


### PR DESCRIPTION
Added in new `__repr__` methods instead (automatically `__str__` anyway, since none is explicitly defined). That means print strings are now more informative:
```python
import porchlight

@porchlight.Door
def my_func(x: int = 1) -> float:
    x_flt = float(x)
    return x_flt

nbr = porchlight.Neighborhood()
nbr.add_door(my_func)

print(nbr)
```
This would output the following string to the terminal:
```
Neighborhood(doors={'my_func': BaseDoor(name=my_func, base_function=<function my_func at 0x7f1e6ff15360>, arguments={'x': <class 'int'>}, return_vals=[['x_flt']])}, params={'x': Param(name=x, value=1, constant=False, type=<class 'int'>), 'x_flt': Param(name=x_flt, value=<porchlight.param.Empty object at 0x7f1e6fff9c60>, constant=False, type=<class 'porchlight.param.Empty'>)}, call_order=['my_func'])
```

Admittedly not the prettiest, but this should be generally informative. This addresses issue #2.