### PR TITLE
10 add tests for neighborhoodorder doors

### DIFF
--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -343,8 +343,7 @@ class Neighborhood:
         ---------
         order : :py:obj:`list`, str
             The order for doors to be called in. Each `str` must correspond to
-            a key in `Neighborhood._doors` at the time of calling this
-            method.
+            a key in `Neighborhood._doors`.
         """
         if any(n not in self._doors for n in order):
             i = [n not in self._doors for n in order].index(True)

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -264,6 +264,40 @@ class TestNeighborhood(TestCase):
         with self.assertRaises(ParameterError):
             neighborhood.run_step()
 
+    def test_order_doors(self):
+        neighborhood = Neighborhood()
+
+        @Door
+        def test1(x, y, z=1):
+            x += y + z
+            return x
+
+        @Door
+        def test2(z):
+            z *= 5
+            return z
+
+        @Door
+        def test3():
+            pass
+
+        @Door
+        def test4(x):
+            outstr = str(f"My x is: {x}")
+            return outstr
+
+        neighborhood.add_door([test1, test2, test3, test4])
+
+        self.assertEqual(
+            neighborhood._call_order, ["test1", "test2", "test3", "test4"]
+        )
+
+        neighborhood.order_doors(["test2", "test1", "test4", "test3"])
+
+        self.assertEqual(
+            neighborhood._call_order, ["test2", "test1", "test4", "test3"]
+        )
+
     def test_remove_door(self):
         @Door
         def test1(x, y, z=1):


### PR DESCRIPTION
Added a very basic test for `porchlight.Neighborhood.order_doors`, which basically just ensures that `Neighborhood._call_order` is updated.