### PR TITLE
Hotfix for door decorators

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -3,7 +3,7 @@ import re
 
 from .param import Empty, ParameterError, Param
 from .utils.typing_functions import decompose_type
-from .utils.inspect_functions import get_all_source
+from .utils.inspect_functions import get_all_source, get_wrapped_function
 
 import typing
 from typing import Any, Callable, Dict, List, Type
@@ -131,7 +131,9 @@ class BaseDoor:
         information accessible to :py:obj:`inspect.Signature` relevant to
         `BaseDoor`.
         """
-        function = self._base_function
+        # Need to find the un-wrapped function that actually takes the
+        # arguments in the end.
+        function = get_wrapped_function(self._base_function)
 
         self.name = function.__name__
         self.__name__ = function.__name__

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -12,8 +12,6 @@ import os
 
 from typing import Callable
 
-logging.basicConfig(filename=f"{os.getcwd()}/porchlight_unittest.log")
-
 
 class TestBaseDoor(TestCase):
     def test___init__(self):
@@ -54,6 +52,40 @@ class TestBaseDoor(TestCase):
         self.assertEqual(fxn_use_decorator.name, "fxn_use_decorator")
 
         self.assertEqual(fxn_use_decorator.arguments, {"x": Empty})
+
+        # Test on a decorated function.
+        def test_decorator(fxn):
+            def wrapper(*args, **kwargs):
+                return fxn(*args, **kwargs)
+
+            return wrapper
+
+        @test_decorator
+        def test_fxn(x: int) -> int:
+            y = 2 * x
+            return y
+
+        door = BaseDoor(test_fxn)
+
+        # Must contain both input and output parameter.
+        arguments = ["x"]
+        keyword_args = ["x"]
+        return_vals = [["y"]]
+
+        # Not comparing any values during this test.
+        for arg in arguments:
+            self.assertIn(arg, door.arguments)
+
+        for kwarg in keyword_args:
+            self.assertIn(kwarg, door.keyword_args)
+
+        for retval in return_vals:
+            self.assertIn(retval, door.return_vals)
+
+        # Call the BaseDoor
+        result = door(x=5)
+
+        self.assertEqual(result, 10)
 
     def test___call__(self):
         def test_fxn(x: int) -> int:
@@ -167,7 +199,6 @@ class TestBaseDoor(TestCase):
 
         self.assertEqual(result, [["y"]])
 
-        # TODO: Below is commented out intentionally for github issue #17.
         # Test decorators.
         def dummy_decorator(fun) -> Callable:
             def wrapper(*args, **kwargs):

--- a/porchlight/utils/inspect_functions.py
+++ b/porchlight/utils/inspect_functions.py
@@ -36,3 +36,25 @@ def get_all_source(function: Callable) -> Tuple[List[str], int]:
     sourcelines = inspect.getsourcelines(function)
 
     return sourcelines
+
+
+def get_wrapped_function(function: Callable) -> Callable:
+    """If the input callable has the `__closure__` attr and its first cell is a
+    function, it will descend until it has found a callable object with no
+    `__closure__` variable.
+    """
+    if not isinstance(function, Callable):
+        raise TypeError(
+            f"Source lines can only be retrieved for Callable "
+            f"objects, not {type(function)}."
+        )
+
+    if "__closure__" in dir(function) and function.__closure__:
+        # Recursively dive down. the first closure cell value should be the
+        # next function down.
+        cell = function.__closure__[0].cell_contents
+
+        if isinstance(cell, Callable) and not isinstance(cell, Type):
+            return get_wrapped_function(function.__closure__[0].cell_contents)
+
+    return function


### PR DESCRIPTION
This fixes a problem with `BaseDoor` still handling the wrapper function for everything except the function's return values.