### PR TITLE
16 map arguments from function variables to neighborhood variables

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -1,6 +1,8 @@
+import functools
 import inspect
 import itertools
 import re
+import types
 
 from .param import Empty, ParameterError, Param
 from .utils.typing_functions import decompose_type
@@ -197,6 +199,14 @@ class BaseDoor:
         self.return_vals = self._get_return_vals(function)
 
         logger.debug(f"Found {self.n_args} arguments in {self.name}.")
+
+    @property
+    def __closure__(self):
+        """Since BaseDoor is a wrapper, and we use utils.get_all_source to
+        retrieve source, I'm mimicking the type a function wrapper would have
+        here.
+        """
+        return (types.CellType(self._base_function),)
 
     def __call__(self, *args, **kwargs):
         """Calls the BaseDoor's function as normal.
@@ -451,12 +461,12 @@ class Door(BaseDoor):
         """
         for key, value in argmap.items():
             # Argument map should contain valid python variable names.
-            if not re.match(r"^[a-zA-Z_]([a-zA-Z0-9_])*", key):
+            if not re.match(r"^[a-zA-Z_]([a-zA-Z0-9_])*$", key):
                 msg = f"Not a valid map name: {key}"
                 logging.error(msg)
                 raise DoorError(msg)
 
-            if not re.match(r"^[a-zA-Z_]([a-zA-Z0-9_])*", value):
+            if not re.match(r"^[a-zA-Z_]([a-zA-Z0-9_])*$", value):
                 msg = f"Not a valid argument name: {value}"
                 logging.error(msg)
                 raise DoorError(msg)

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -402,7 +402,32 @@ class Door(BaseDoor):
 
             return self
 
-        return super().__call__(*args, **kwargs)
+        # Check argument mappings.
+        if not self.argmap:
+            # Just pass arguments normally
+            return super().__call__(*args, **kwargs)
+
+        input_kwargs = {}
+        for key, value in kwargs.items():
+            if key in self.argmap:
+                input_kwargs[self.argmap[key]] = value
+
+            else:
+                input_kwargs[key] = value
+
+        # Temporarily restore the original arguments for the purposes of
+        # 'BaseDoor.__call__'.
+        _temp_arguments = self.arguments
+        _temp_keyword_arguments = self.keyword_args
+        self.arguments = self.original_arguments
+        self.keyword_args = self.original_kw_arguments
+
+        result = super().__call__(*args, **input_kwargs)
+
+        self.arguments = _temp_arguments
+        self.keyword_args = _temp_keyword_arguments
+
+        return result
 
     def map_arguments(self):
         """Maps arguments if self.argmap is not {}."""
@@ -639,7 +664,7 @@ class DynamicDoor(Door):
             `~porchlight.door.DynamicDoor._base_function`.
         """
         self.update()
-        result = self._base_function(*args, **kwargs)
+        result = super().__call__(*args, **kwargs)
 
         return result
 

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -259,11 +259,6 @@ class BaseDoor:
         function : :py:class:`typing.Callable`
             The function to retrieve the return values for.
         """
-        # If function is a Door, peel away Door wrappings until it's a non-Door
-        # callable.
-        while isinstance(function, BaseDoor):
-            function = function._base_function
-
         return_vals = []
 
         lines, start_line = get_all_source(function)

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -432,6 +432,10 @@ class Door(BaseDoor):
                     self.keyword_args[mapped_name] = self.keyword_args[
                         old_name
                     ]
+
+                    # Need to change the parameter name to reflect the mapping.
+                    self.keyword_args[mapped_name]._name = mapped_name
+
                     del self.keyword_args[old_name]
 
                 # Also change outputs that contain the same name.

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -389,6 +389,11 @@ class Door(BaseDoor):
                 logger.error(msg)
                 raise ValueError(msg)
 
+            if not isinstance(args[0], Callable):
+                msg = f"Cannot initialize this object as a door: {args[0]}"
+                logger.error(msg)
+                raise TypeError(msg)
+
             function = args[0]
             super().__init__(function)
             self.function_initialized = True

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -498,6 +498,20 @@ class Door(BaseDoor):
         return arguments
 
     @property
+    def original_kw_arguments(self):
+        arguments = copy.copy(self.keyword_args)
+
+        for i, arg in enumerate(self.keyword_args):
+            if arg in self.argmap:
+                orig_arg = self.argmap[arg]
+                _type = arguments[arg]
+
+                arguments[orig_arg] = _type
+                del arguments[arg]
+
+        return arguments
+
+    @property
     def original_return_vals(self):
         return_vals = copy.copy(self.return_vals)
 
@@ -515,7 +529,10 @@ class Door(BaseDoor):
 
     @argument_mapping.setter
     def argument_mapping(self, value):
+        self.arguments = self.original_arguments
+        self.keyword_args = self.original_kw_arguments
         self.argmap = value
+        self.map_arguments()
 
     @property
     def variables(self) -> List[str]:

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -181,11 +181,6 @@ class Neighborhood:
 
         return_types = new_door.return_types
 
-        if len(return_types) != len(new_door.return_vals[0]):
-            raise NeighborhoodError(
-                "Dynamic doors with return values must be type annotated."
-            )
-
         for i, rt in enumerate(return_types):
             if isinstance(rt, door.Door) or rt is door.Door:
                 ret_val = new_door.return_vals[0][i]

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -151,7 +151,7 @@ class Neighborhood:
                 self.add_param(parameter_name, value)
 
         # If not well-defined, we cannot modify outputs to this function.
-        if not new_door.return_vals:
+        if not new_door.return_vals and not dynamic_door:
             return
 
         # Add all return values as parameters.
@@ -167,7 +167,10 @@ class Neighborhood:
         #
         # Dynamic doors must also be type-annotated. If they are not raise an
         # error.
-        if not new_door.return_types:
+        if (
+            "return_types" not in new_door.__dict__
+            or not new_door.return_types
+        ):
             msg = (
                 "DynamicDoor requires a type annotation for the "
                 "function generator."
@@ -178,9 +181,7 @@ class Neighborhood:
 
         return_types = new_door.return_types
 
-        if not return_types or len(return_types) != len(
-            new_door.return_vals[0]
-        ):
+        if len(return_types) != len(new_door.return_vals[0]):
             raise NeighborhoodError(
                 "Dynamic doors with return values must be type annotated."
             )

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -232,6 +232,47 @@ class TestBaseDoor(TestCase):
         self.assertFalse(fxn1 == fxn2)
         self.assertTrue(fxn1 == other_fxn1)
 
+    def test_nested_door(self):
+        # Without applying as a decorator.
+        def test1(x, y: int):
+            z = x + y
+            return z
+
+        door1 = BaseDoor(test1)
+        door2 = BaseDoor(door1)
+
+        self.assertEqual(door1.arguments, door2.arguments)
+        self.assertEqual(door1.keyword_arguments, door2.keyword_arguments)
+        self.assertEqual(door1.return_vals, door2.return_vals)
+
+        # With one decorator
+        @BaseDoor
+        def door1(x, y: int):
+            z = x + y
+            return z
+
+        door2 = BaseDoor(door1)
+
+        self.assertEqual(door1.arguments, door2.arguments)
+        self.assertEqual(door1.keyword_arguments, door2.keyword_arguments)
+        self.assertEqual(door1.return_vals, door2.return_vals)
+
+        # With two decorators
+        @BaseDoor
+        @BaseDoor
+        def door2(x, y: int):
+            z = x + y
+            return z
+
+        @BaseDoor
+        def door1(x, y: int):
+            z = x + y
+            return z
+
+        self.assertEqual(door1.arguments, door2.arguments)
+        self.assertEqual(door1.keyword_arguments, door2.keyword_arguments)
+        self.assertEqual(door1.return_vals, door2.return_vals)
+
     def test___repr__(self):
         """Test the BaseDoor"""
 

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -2,6 +2,7 @@
 relevant helper functions or objects.
 """
 from unittest import TestCase
+import unittest
 
 from porchlight.door import Door
 from porchlight.param import Empty, ParameterError
@@ -152,8 +153,25 @@ class TestDoor(TestCase):
         test_door = Door(test)
         self.assertEqual(repr(test_door), expected_repr)
 
+    def test_mapping_args(self):
+        @Door(argument_mapping={"hello": "x", "world": "y"})
+        def my_func(x, y):
+            z = x + y
+            x = x - 1
+            return z, x
+
+        @Door
+        def orig_func(x, y):
+            z = x + y
+            x = x - 1
+            return z, x
+
+        self.assertEqual(my_func.variables, ["hello", "world", "z"])
+        self.assertEqual(my_func.return_vals, [["z", "hello"]])
+        self.assertEqual(my_func.required_arguments, ["hello", "world"])
+        self.assertEqual(my_func.original_arguments, orig_func.arguments)
+        self.assertEqual(my_func.original_return_vals, orig_func.return_vals)
+
 
 if __name__ == "__main__":
-    import unittest
-
     unittest.main()

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -281,6 +281,29 @@ class TestDoor(TestCase):
             def test1():
                 pass
 
+    def test_bad_mapping_uninitialized(self):
+        with self.assertRaises(DoorError):
+            my_door = Door(argument_mapping={})
+            my_door.map_arguments()
+
+    def test_bad_call_inputs(self):
+        with self.assertRaises(TypeError):
+            Door(argument_mapping={})(1)
+
+        with self.assertRaises(ValueError):
+
+            def test1():
+                pass
+
+            Door(argument_mapping={})(test1, 1, y=2)
+
+    def test_bad_mapping_name_err_and_warning(self):
+        with self.assertRaises(DoorError):
+
+            @Door(argument_mapping={"x": "y"})
+            def test1(x, y):
+                pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -304,6 +304,17 @@ class TestDoor(TestCase):
             def test1(x, y):
                 pass
 
+    def test_argument_mapping_property(self):
+        @Door(argument_mapping={"hello": "x", "world": "z"})
+        def test1(x, y: int, z=1) -> int:
+            total = x + y * z
+            return total
+
+        self.assertEqual(test1.argument_mapping, {"hello": "x", "world": "z"})
+
+        # Changing the argument mapping with the setter.
+        test1.argument_mapping = {"hello_again": "x", "world_two": "z"}
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -263,6 +263,16 @@ class TestDoor(TestCase):
             cur_map = {name: "x"}
             Door(argument_mapping=cur_map)(base_def)
 
+    def test_nested_mapping(self):
+        @Door(argument_mapping={"hello": "x", "world": "z"})
+        def test1(x, y: int, z=1) -> int:
+            total = x + y * z
+            return total
+
+        test2 = Door(test1)
+
+        self.assertEqual(test2.arguments, {"x": Empty, "y": int, "z": Empty})
+
     def test_bad_mapping_bad_functions(self):
         # A bad argument
         with self.assertRaises(DoorError):

--- a/porchlight/tests/test_dynamicdoor.py
+++ b/porchlight/tests/test_dynamicdoor.py
@@ -115,6 +115,11 @@ class TestDynamicDoor(unittest.TestCase):
 
         self.assertEqual(result, 1)
 
+        dynamicdoor.generator_kwargs = {"hello": 5, "y": 5}
+
+        result = dynamicdoor()
+        self.assertEqual(result, 5 ** 5)
+
     def test_call_without_update(self):
         @door.DynamicDoor
         def test1(x: int = 4) -> door.Door:

--- a/porchlight/tests/test_dynamicdoor.py
+++ b/porchlight/tests/test_dynamicdoor.py
@@ -83,6 +83,20 @@ class TestDynamicDoor(unittest.TestCase):
                 new_ddoor = door.DynamicDoor(test)
                 new_ddoor.update()
 
+    def test_argument_mapping(self):
+        @door.DynamicDoor
+        def doorgen1() -> door.Door:
+            @door.Door(argument_mapping={"hello": "x"})
+            def my_door(x: int, y: int = 1) -> int:
+                z = x ** y
+                return z
+
+            return my_door
+
+        self.assertEqual(doorgen1(2, 5), 2 ** 5)
+        self.assertEqual(doorgen1.arguments, {"hello": int, "y": int})
+        self.assertEqual(doorgen1.return_vals, [["z"]])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -631,6 +631,20 @@ class TestNeighborhood(TestCase):
         self.assertEqual(result["x"], Param("x", porchlight.param.Empty()))
         self.assertEqual(result["y"], Param("y", "15.5"))
 
+    def test_bad_dynamicdoor_return_values(self):
+        @porchlight.door.DynamicDoor
+        def test1():
+            def bad():
+                x = 1
+                return x
+
+            return bad
+
+        neighborhood = Neighborhood()
+
+        with self.assertRaises(porchlight.neighborhood.NeighborhoodError):
+            neighborhood.add_door(test1, dynamic_door=True)
+
 
 if __name__ == "__main__":
     import unittest

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -563,7 +563,7 @@ class TestNeighborhood(TestCase):
 
         # Add two dynamic doors using a single generator function.
         def doublegen_test(
-            x: int,
+            x: float,
         ) -> typing.Tuple[porchlight.Door, porchlight.Door]:
             @porchlight.Door
             def test1(y: float) -> float:
@@ -579,8 +579,8 @@ class TestNeighborhood(TestCase):
 
         neighborhood = Neighborhood()
         neighborhood.add_function(doublegen_test, dynamic_door=True)
-        neighborhood.add_param("x", 0)
-        neighborhood.add_param("y", 2)
+        neighborhood.add_param("x", 0.0)
+        neighborhood.add_param("y", 2.0)
 
         expected_doors = ["doublegen_test", "test1", "test2"]
         expected_params = ["x", "test1", "test2", "y", "z"]
@@ -590,16 +590,16 @@ class TestNeighborhood(TestCase):
         neighborhood.run_step()
 
         self.assertEqual(list(neighborhood.params.keys()), expected_params)
-        self.assertEqual(neighborhood.params["x"].value, 4)
-        self.assertEqual(neighborhood.params["y"].value, 2)
-        self.assertEqual(neighborhood.params["z"].value, 2)
+        self.assertAlmostEqual(neighborhood.params["x"].value, 4.0)
+        self.assertAlmostEqual(neighborhood.params["y"].value, 2.0)
+        self.assertAlmostEqual(neighborhood.params["z"].value, 2.0)
 
         neighborhood.run_step()
 
         self.assertEqual(list(neighborhood.params.keys()), expected_params)
-        self.assertEqual(neighborhood.params["x"].value, 34)
-        self.assertEqual(neighborhood.params["y"].value, 2)
-        self.assertEqual(neighborhood.params["z"].value, 17)
+        self.assertAlmostEqual(neighborhood.params["x"].value, 34.0)
+        self.assertAlmostEqual(neighborhood.params["y"].value, 2.0)
+        self.assertAlmostEqual(neighborhood.params["z"].value, 17.0)
 
     def test_bad_dynamic_door(self):
         @Door

--- a/porchlight/utils/inspect_functions.py
+++ b/porchlight/utils/inspect_functions.py
@@ -45,8 +45,8 @@ def get_wrapped_function(function: Callable) -> Callable:
     """
     if not isinstance(function, Callable):
         raise TypeError(
-            f"Source lines can only be retrieved for Callable "
-            f"objects, not {type(function)}."
+            f"Only Callable objects may be unwrapped in this way, "
+            f"not {type(function)}."
         )
 
     if "__closure__" in dir(function) and function.__closure__:


### PR DESCRIPTION
This PR resolves issue #16 by reformatting `Door` to accept arguments at initialization, not just the function. To map arguments, it's just some extra info in the header:
```python
@porchlight.Door(argument_mapping={'hello': 'x'})
def my_func(x):
    z = x**2
    return z

print(my_func)
# Out >>> Door(name=my_func, base_function=<function my_func at 0x7fed0143fac0>, arguments={'hello': <class 'porchlight.param.Empty'>}, return_vals=[['z']])
```
This removes the need to define independent wrapper functions, allows for the underlying mappings to be preserved without re-parsing source.

This comes with many new tests, specifically for `BaseDoor` and `Door`.