### PR TITLE
Adding restrict to parameters.

### DIFF
--- a/porchlight/param.py
+++ b/porchlight/param.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any, Callable, Type, Union
 
 import logging
 
@@ -56,10 +56,14 @@ class Param:
     # A parameter, to be updated from the API, needs to be replaced rather than
     # reassigned. That said there are a few use cases where it may be useful to
     # have easy access, so just hiding these behind properties.
-    __slots__ = ["_name", "_value", "constant", "_type"]
+    __slots__ = ["_name", "_value", "constant", "_type", "restrict"]
 
     def __init__(
-        self, name: str, value: Any = Empty(), constant: bool = False
+        self,
+        name: str,
+        value: Any = Empty(),
+        constant: bool = False,
+        restrict: Union[Callable, None] = None,
     ):
         """Initializes the Param object.
 
@@ -72,15 +76,21 @@ class Param:
             Value of the parameter. If the parameter does not contain an
             assigned value, this should be `~porchlight.param.Empty`
 
-        constants : :py:obj:`bool`
+        constant : :py:obj:`bool`
             True if this object should be considered a constant. If the `Param`
             value is modified by `Param.value`'s `setter`, but `constant` is
             True, a :class:`~porchlight.param.ParameterError` will be raised.
+
+        restrict : :py:class:`~typing.Callable` or `None`
+            If a callable is passed, whenever the value property of the
+            parameter is set, restrict will be called on the candidate value.
+            If the result evaluates to False, a ParameterError will be raised.
         """
         self._name = name
         self._value = value
         self.constant = constant
         self._type = type(self._value)
+        self.restrict = restrict
 
     def __repr__(self):
         info = {
@@ -120,6 +130,12 @@ class Param:
             msg = f"Parameter {self.name} is not mutable."
             logger.error(msg)
             raise ParameterError(msg)
+
+        if self.restrict is not None:
+            if not self.restrict(new_value):
+                msg = f"Parameter restriction rejected value: {new_value}"
+                logger.error(msg)
+                raise ParameterError(msg)
 
         self._value = new_value
 

--- a/porchlight/tests/test_param.py
+++ b/porchlight/tests/test_param.py
@@ -83,6 +83,21 @@ class ParamTest(TestCase):
         with self.assertRaises(param.ParameterError):
             testparam.value = "bing"
 
+    def test_restrict_value(self):
+        # Parameter should be set with a keyword that, if passed, is called on
+        # the new set value.
+        p = param.Param("test", 0.5, restrict=lambda x: x > 0)
+
+        # Here, zero + negative values must raise a ParameterError.
+        with self.assertRaises(param.ParameterError):
+            p.value = -1
+
+        with self.assertRaises(param.ParameterError):
+            p.value = 0.0
+
+        # However, positive values should be fine in this case.
+        p.value = 1.0
+
 
 class TestEmpty(TestCase):
     def test___eq__(self):


### PR DESCRIPTION
This is a straightforward, but important, update to the way `Param` accepts/rejects values.

Alongside `Param.constant`, which when `True` will always take precedence, `Param.restrict` can now contain a callable (e.g., a lambda function) that returns some value that can be evaluated to `True` or `False`. This doesn't restrict the output to be boolean, e.g., `[]` and `[1]` are `False` and `True`, respectively.

Here's an example of the behavior:
```python
from porchlight import Param
import porchlight

par = Param("x", 1, restrict=lambda x: x > 0)

# Now, assigning a value to par that is less than or equal to 0 will raise an error
try:
    par.value = -1
except porchlight.param.ParameterError as e:
    print(f"ParameterError: {e}")
```

The default value of `restrict` is `None`, which skips any check.