### PR TITLE
15 add self checking parameter option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 
 # coverage files
 htmlcov/
+git_filter.py

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -267,7 +267,11 @@ class Neighborhood:
         )
 
     def add_param(
-        self, parameter_name: str, value: Any, constant: bool = False
+        self,
+        parameter_name: str,
+        value: Any,
+        constant: bool = False,
+        restrict: Union[Callable, None] = None,
     ):
         """Adds a new parameter to the `Neighborhood` object.
 
@@ -284,9 +288,17 @@ class Neighborhood:
 
         constant : :py:obj:`bool`, optional
             If `True`, the parameter is set to constant.
+
+        restrict : :py:class:`~typing.Callable` or None, optional
+            Either a callable that returns something that can be evaluated to
+            True or False, or None. Raises an error if the parameter is set to
+            a value that fails the restriction check.
+
+            For a full description, see the docs for
+            :class:`~parameter.param.Param`.
         """
         if not isinstance(value, param.Param):
-            new_param = param.Param(parameter_name, value, constant)
+            new_param = param.Param(parameter_name, value, constant, restrict)
 
         else:
             new_param = value


### PR DESCRIPTION
This is a straightforward, but important, update to the way `Param` accepts/rejects values.

Alongside `Param.constant`, which when `True` will always take precedence, `Param.restrict` can now contain a callable (e.g., a lambda function) that returns some value that can be evaluated to `True` or `False`. This doesn't restrict the output to be boolean, e.g., `[]` and `[1]` are `False` and `True`, respectively.

Here's an example of the behavior:
```python
from porchlight import Param
import porchlight

par = Param("x", 1, restrict=lambda x: x > 0)

# Now, assigning a value to par that is less than or equal to 0 will raise an error
try:
    par.value = -1
except porchlight.param.ParameterError as e:
    print(f"ParameterError: {e}")
```

The default value of `restrict` is `None`, which skips any check.