### PR TITLE
18 allow positional only arguments in functions

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -31,6 +31,9 @@ class BaseDoor:
         Dictionary of all arguments taken as input when the `BaseDoor` object
         is called.
 
+    positional_only : :py:obj:`list` of :py:obj:`str`
+        List of positional-only arguments accepted by the function.
+
     keyword_args : :py:obj:`dict`, :py:obj:`str`: :class:`~typing.Any`
         Keyword arguments accepted by the `BaseDoor` as input when called. This
         includes all arguments that are not positional-only. Positional
@@ -146,6 +149,7 @@ class BaseDoor:
         self.name = function.__name__
         self.__name__ = function.__name__
         self.arguments = {}
+        self.positional_only = []
         self.keyword_args = {}
         self.keyword_only_args = {}
 
@@ -164,19 +168,19 @@ class BaseDoor:
 
             self.return_types = None
 
+        # Use function signature to introspect properties about the parameters.
         for name, param in inspect.signature(function).parameters.items():
             self.arguments[name] = param.annotation
 
             # Check for positional-only arguments first, then proceed to other
             # argument types.
             if param.kind == inspect.Parameter.POSITIONAL_ONLY:
-                msg = (
-                    f"porchlight does not support positional-only "
-                    f"arguments, which were found in {self.name}."
-                )
-
-                logger.error(msg)
-                raise NotImplementedError(msg)
+                # Positional-only arguments will not support default values for
+                # the function. That said, this is effectively overriden by
+                # Neighborhood objects, since they store the parameter's value
+                # and pass it regardless of whether the argument is
+                # positional-only or not.
+                self.positional_only.append(name)
 
             elif param.default != inspect._empty:
                 self.keyword_args[name] = Param(name, param.default)

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -298,15 +298,24 @@ class TestBaseDoor(TestCase):
 
         self.assertEqual(new_door.keyword_only_args, {"z": Param("z", 5)})
 
-        # For now, there should *not* be any functionality for required
-        # positional arguments. That will come later, and this test will need
-        # to be updated.
-        def bad_fxn(x1, y1, /, x3, *, z7):
-            c = "blah"
-            return c
+        # Positional-only arguments.
+        def test1(
+            pos1, pos2, /, kwpos, kwposdef="default", *, kwonly="def4ult"
+        ):
+            pass
 
-        with self.assertRaises(NotImplementedError):
-            BaseDoor(bad_fxn)
+        new_door = BaseDoor(test1)
+
+        expected_arguments = {
+            "pos1": Empty(),
+            "pos2": Empty(),
+            "kwpos": Empty(),
+            "kwposdef": Empty(),
+            "kwonly": Empty,
+        }
+
+        self.assertEqual(new_door.arguments, expected_arguments)
+        self.assertEqual(new_door.positional_only, ["pos1", "pos2"])
 
     def test__returned_def_to_door(self):
         def my_func_gen():


### PR DESCRIPTION
This allows for positional-only arguments to be passed to `Door`s and properly handled. The only caveat being that this behavior is somewhat illusory within `porchlight` as a whole, since the way `Neighborhood` objects handle parameters negates the functional purpose of positional-only arguments as it is.

Therefore, the meat of this update is allowing for more Python syntax flexibility.

## Summary
This update allows for `/` to be used within function argument specifications such as the following:
```python
from porchlight import Door

@Door
def strict_function(arg1, arg2, \, arg3):
   return sum([arg1, arg2, arg3])
```

Here, `arg1` and `arg2` are [*positional-only arguments*](https://peps.python.org/pep-0570/), meaning they cannot be passed out-of-order, as keywords, and cannot be omitted from the argument list. Unlike `arg3`, they also cannot be specified using `arg1=`/as keywords.

Although this may not be a super common use case, better to handle it rather than raise an error as it does currently.