### PR TITLE
Teald get param method neighborhood

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ coupling Python functions and managing shared data.
    :caption: Contents:
 
    other/about
+   other/quickstart
    source/neighborhood
    source/door
    source/param

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,14 @@
 Welcome to porchlight's documentation!
 ======================================
 
+`porchlight` is an open-source function management package designed for
+coupling Python functions and managing shared data.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
+   other/about
    source/neighborhood
    source/door
    source/param

--- a/docs/other/about.rst
+++ b/docs/other/about.rst
@@ -1,0 +1,16 @@
+About `porchlight`
+==================
+
+Functionality
+-------------
+
+* Control external access to shared data.
+* Automate coupling models with shared, evolving parameter sets.
+* Set parameter limits to catch unique error cases, such as unphysical conditions or numerical instabilities.
+* Couple models in a single, short script, without hand-managing input files or writing long single-use automation scripts.
+
+FAQ
+---
+
+# Why is it called `porchlight`?
+  * `porchlight` was decided on to be reminiscent of illumination and community; it aims to help others make incredible things and to "bring light" to the doorsteps of otherwise inaccessible models. Most importantly; it was available on the Python Package Index at the time and is relatively memorable.

--- a/docs/other/about.rst
+++ b/docs/other/about.rst
@@ -10,6 +10,8 @@ Functionality
   conditions or numerical instabilities.
 * Couple models in a single, short script, without hand-managing input files or
   writing long single-use automation scripts.
+* Provides a basic API for making development and research more accessible to
+  early developers.
 
 FAQ
 ---
@@ -33,7 +35,8 @@ FAQ
        to implementing and testing that idea ASAP.
     *  Coupling different programs together for specific use cases.
     *  Expanding your own code without writing new, specific implementations
-      for integrating new software.
+       for integrating new software.
+    *  Need a quick, basic API for an otherwise complex input/output system.
   * You *should consider other options* if you're looking for:
     * A permanent solution for poorly designed codebases. While in spirit
       `porchlight` is meant to circumvent hardships weird APIs (or complete

--- a/docs/other/about.rst
+++ b/docs/other/about.rst
@@ -6,11 +6,39 @@ Functionality
 
 * Control external access to shared data.
 * Automate coupling models with shared, evolving parameter sets.
-* Set parameter limits to catch unique error cases, such as unphysical conditions or numerical instabilities.
-* Couple models in a single, short script, without hand-managing input files or writing long single-use automation scripts.
+* Set parameter limits to catch unique error cases, such as unphysical
+  conditions or numerical instabilities.
+* Couple models in a single, short script, without hand-managing input files or
+  writing long single-use automation scripts.
 
 FAQ
 ---
 
-# Why is it called `porchlight`?
-  * `porchlight` was decided on to be reminiscent of illumination and community; it aims to help others make incredible things and to "bring light" to the doorsteps of otherwise inaccessible models. Most importantly; it was available on the Python Package Index at the time and is relatively memorable.
+#. Why is it called `porchlight`?
+  * `porchlight` was decided on to be reminiscent of illumination and
+    community; it aims to help others make incredible things and to "bring
+    light" to the doorsteps of otherwise inaccessible models. Most importantly;
+    it was available on the Python Package Index at the time and is relatively
+    memorable.
+#. Why does everything have regular noun names, like
+   :class:`~porchlight.door.Door` or
+   :class:`~porchlight.neighborhood.Neighborhood`?
+  * To match the name of the software + to provide clear visualization of how
+    the objects function. That said, `porchlight` is still in alpha so it could
+    change by beta!
+#. Why should I use `porchlight`? Are there situations where I *shouldn't* use
+   it?
+  * You *should use* this if you're:
+    *  Looking for something to make getting from an interesting question/idea
+       to implementing and testing that idea ASAP.
+    *  Coupling different programs together for specific use cases.
+    *  Expanding your own code without writing new, specific implementations
+      for integrating new software.
+  * You *should consider other options* if you're looking for:
+    * A permanent solution for poorly designed codebases. While in spirit
+      `porchlight` is meant to circumvent hardships weird APIs (or complete
+      lack of and API) present to hitting the ground running without coupling
+      models.
+    * Threading/multiprocessing manager.
+    * Static or partially-static typing schemes (use `mypy` or another strict
+      typing checker).

--- a/docs/other/quickstart.rst
+++ b/docs/other/quickstart.rst
@@ -34,9 +34,66 @@ You can install `porchlight` directly using `pip`:
 ..code-block:: python
     import porchlight
 
-Creating a `Door` object
-========================
+Creating a `Neighborhood` object
+================================
 
 The `Door` class acts as an interface (an "open door") to the internals of a
 python function object. To create one, we just need to import porchlight
-and
+and provide the function we want.
+..code-block:: python
+    def my_function(x: int, z: int = 0) -> int:
+        '''This is a simple equation, but we want to return a named variable.'''
+        y = x ** 2 + z
+        return y
+
+
+    neighborhood = porchlight.Neighborhood()  # Instantiates the object.
+    neighborhood.add_function(my_function)
+
+At this point, `porchlight` will parse the function and store metadata about
+it. The `str` representation of Neighborhood contains most of the data:
+..code-block:: python
+    print(neighborhood)
+    # >>  Neighborhood(doors={'my_function': Door(name=my_function, base_function=<function my_function at 0x1...F>, arguments={}, return_vals=[['y']])}, params={'y': Param(name=y, value=<porchlight.param.Empty object at 0x1...F>, constant=False, type=<class 'porchlight.param.Empty'>)}, call_order=['my_function'])
+
+A few things are now kept track of by the neighborhood automatically:
+#. The function arguments, now tracked as a :class:`~porchlight.param.Param`
+   object. The default values found were sazed (in our case, it found `z = 0`),
+   and any parameters not yet assigned a value have been given the
+   :class:`~porchlight.param.Empty` value.
+#. Function return variables. We'll explore this in more detail later, but one
+   important note here: the return variable name is important!
+
+Right now, our :class:`~porchlight.neighborhood.Neighborhood` is a
+fully-fledged, if tiny, model. Let's set our variables and run it!
+
+..code-block:: python
+    neighborhood.set_param('x', 2)
+    neighborhood.set_param('z', 0)
+
+    neighborhood.run_step()
+    print(neighborhood)
+    # Neighborhood(doors={'my_function': Door(name=my_function, base_function=<function my_function at 0x1...f>, arguments={'x': <class 'int'>, 'z': <class 'int'>}, return_vals=[['y']])}, params={'x': Param(name=x, value=2, constant=False, type=<class 'int'>), 'z': Param(name=z, value=0, constant=False, type=<class 'int'>), 'y': Param(name=y, value=4, constant=False, type=<class 'int'>)}, call_order=['my_function'])
+
+:function:`~porchlight.neighborhood.Neighborhood.run_step` executes all
+functions that have been added to our `neighborhood` object. The object passes
+the parameters with names matching the arguments in `my_function`, and stores
+`my_function`'s output in the parameter for `y`.
+
+All of this could be accomplished in a few lines of code without any imports,
+obviously. We could manage our own `x`, `y`, and `z` in a heartbeat, and all
+`porchlight` *really* did was what we could do with something as simple as
+`y = my_function(2, 0)`. Let's add another function to our neighborhood and
+call :function:`~porchlight.neighborhood.Neighborhood.run_step`
+
+..code-block:: python
+    def my_new_function(y, z):
+        z += y // 2
+        return z
+
+    neighborhood.add_function(my_new_function)
+
+    # Let's run Neighborhood.run_step() a few times and see how the system
+    # evolves by printing out the parameters.
+    for i in range(5):
+        neighborhood.run_step()

--- a/docs/other/quickstart.rst
+++ b/docs/other/quickstart.rst
@@ -1,7 +1,7 @@
 Quickstart
 ==========
 
-Welcome to a quick guide to hitting the ground running with `porchlight`! This
+Welcome to a short guide to hitting the ground running with `porchlight`! This
 tutorial will step through the basics of installing and using `porchlight`. If
 you are looking for more advanced examples, see the examples availabe in our
 `github repository <https://github.com/teald/porchlight/tree/main/examples>`.
@@ -17,13 +17,26 @@ Installation
 
 For help installing Python 3.9 or above please see their respective
 instructions:
+
 * `Python 3.9 or above <https://www.python.org/downloads/>`
 
 You can install `porchlight` directly using `pip`:
 
-.. code-block:: bash
+.. code-block:: console
     :caption: pip installation
     pip install porchlight
 
 
- Once porchlight has installed, you're ready to start writing code.
+ Once porchlight has installed, you're ready to start writing code. If you'd
+ like, this guide can be followed line-for-line in an interactive python
+ environment! To get started, just import the library:
+
+..code-block:: python
+    import porchlight
+
+Creating a `Door` object
+========================
+
+The `Door` class acts as an interface (an "open door") to the internals of a
+python function object. To create one, we just need to import porchlight
+and

--- a/docs/other/quickstart.rst
+++ b/docs/other/quickstart.rst
@@ -1,0 +1,29 @@
+Quickstart
+==========
+
+Welcome to a quick guide to hitting the ground running with `porchlight`! This
+tutorial will step through the basics of installing and using `porchlight`. If
+you are looking for more advanced examples, see the examples availabe in our
+`github repository <https://github.com/teald/porchlight/tree/main/examples>`.
+
+Requirements
+------------
+
+`porchlight` requires *Python version 3.9 or higher*.
+
+
+Installation
+------------
+
+For help installing Python 3.9 or above please see their respective
+instructions:
+* `Python 3.9 or above <https://www.python.org/downloads/>`
+
+You can install `porchlight` directly using `pip`:
+
+.. code-block:: bash
+    :caption: pip installation
+    pip install porchlight
+
+
+ Once porchlight has installed, you're ready to start writing code.

--- a/examples/quickstart_script.py
+++ b/examples/quickstart_script.py
@@ -1,0 +1,57 @@
+"""This script follows the "Quick Start"""
+import porchlight
+
+
+def my_function(x: int, z: int = 0) -> int:
+    """This is a simple equation, but we want to return a named variable."""
+    y = x ** 2 + z
+    return y
+
+
+neighborhood = porchlight.Neighborhood()  # Instantiates the object.
+neighborhood.add_function(my_function)
+
+print(neighborhood)
+# >>> Neighborhood(doors={'my_function': Door(name=my_function,
+#     base_function=<function my_function at 0x1...F>, arguments={},
+#     return_vals=[['y']])}, params={'y': Param(name=y,
+#     value=<porchlight.param.Empty object at 0x1...F>, constant=False,
+#     type=<class 'porchlight.param.Empty'>)}, call_order=['my_function'])
+
+neighborhood.set_param("x", 2)
+neighborhood.set_param("z", 0)
+
+neighborhood.run_step()
+print(neighborhood)
+# >>> Neighborhood(doors={'my_function': Door(name=my_function,
+#     base_function=<function my_function at 0x1...f>, arguments={'x':
+#     <class 'int'>, 'z': <class 'int'>}, return_vals=[['y']])}, params={'x':
+#     Param(name=x, value=2, constant=False, type=<class 'int'>), 'z':
+#     Param(name=z, value=0, constant=False, type=<class 'int'>), 'y':
+#     Param(name=y, value=4, constant=False, type=<class 'int'>)},
+#     call_order=['my_function'])
+
+
+def my_new_function(y, z):
+    z += y // 2
+    return z
+
+
+neighborhood.add_function(my_new_function)
+neighborhood.run_step()
+
+print(neighborhood)
+
+for param in neighborhood.params.values():
+    print(param)
+    # >>> Neighborhood(doors={'my_function': Door(name=my_function,
+    #     base_function=<function my_function at 0x1..f>, arguments={'x':
+    #     <class 'int'>, 'z': <class 'int'>}, return_vals=[['y']])},
+    #     params={'x': Param(name=x, value=2, constant=False, type=<class
+    #     'int'>), 'z': Param(name=z, value=0, constant=False, type=<class
+    #     'int'>), 'y': Param(name=y, value=4, constant=False, type=<class
+    #     'int'>)},
+    # call_order=['my_function'])
+    # >>> Param(name=x, value=2, constant=False, type=<class 'int'>)
+    # >>> Param(name=z, value=0, constant=False, type=<class 'int'>)
+    # >>> Param(name=y, value=4, constant=False, type=<class 'int'>)

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -219,6 +219,17 @@ class Neighborhood:
 
         del self._doors[name]
 
+    def get_value(self, parameter_name: str) -> Any:
+        """Retrieves the value of a parameter by name. Does not return a Param
+        object; it returns whatever data is stored in Param.value.
+
+        Arguments
+        ---------
+        parameter_name : `str`
+            The name of the parameter to retrieve the current value for.
+        """
+        return self._params[parameter_name].value
+
     def set_param(
         self,
         parameter_name: str,

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -32,17 +32,19 @@ class TestNeighborhood(TestCase):
 
         neighborhood.add_door(test1)
 
-        expected = (
-            "Neighborhood(doors={'test1': Door(name=test1, "
-            "base_function=<function test1 at 0x7f247d8c48b0>, "
-            "arguments={'x': <class 'int'>}, return_vals=[['y']])}, "
-            "params={'x': Param(name=x, value=<porchlight.param."
-            "Empty object at 0x7f247e1bd060>, constant=False, type=<class "
-            "'porchlight.param.Empty'>), 'y': Param(name="
-            "y, value=<porchlight.param.Empty object at 0x7f247d8c9660>, "
-            "constant=False, type=<class 'porchlight.param "
-            ".Empty'>)}, call_order=['test1'])"
-        )
+        # Keeping the below as an example of what the string looks like. Update
+        # this to match the actual implementation as changes occur below.
+        # expected = (
+        #     "Neighborhood(doors={'test1': Door(name=test1, "
+        #     "base_function=<function test1 at 0x7f247d8c48b0>, "
+        #     "arguments={'x': <class 'int'>}, return_vals=[['y']])}, "
+        #     "params={'x': Param(name=x, value=<porchlight.param."
+        #     "Empty object at 0x7f247e1bd060>, constant=False, type=<class "
+        #     "'porchlight.param.Empty'>), 'y': Param(name="
+        #     "y, value=<porchlight.param.Empty object at 0x7f247d8c9660>, "
+        #     "constant=False, type=<class 'porchlight.param "
+        #     ".Empty'>)}, call_order=['test1'])"
+        # )
 
         params = neighborhood.params
 
@@ -644,6 +646,26 @@ class TestNeighborhood(TestCase):
 
         with self.assertRaises(porchlight.neighborhood.NeighborhoodError):
             neighborhood.add_door(test1, dynamic_door=True)
+
+    def test_get_value(self):
+        def test1(x, y=1):
+            z = x + y
+            return z
+
+        neighborhood = Neighborhood()
+
+        neighborhood.add_function(test1)
+        neighborhood.set_param("x", 1)
+        neighborhood.run_step()
+
+        expected = {
+            "x": 1,
+            "y": 1,
+            "z": 2,
+        }
+
+        for pname, val in expected.items():
+            self.assertEqual(val, neighborhood.get_value(pname))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a new method to `porchlight.neightborhood.Neighborhood`: `get_value`. This takes a string, as a parameter name, and returns the current `value` attribute of the `Param` object associated with the name string in `Neighborhood._params`.

### Example
```python
from porchlight import Neighborhood

nbrhd = Neighborhood()

def test1(x=1):
    pass

nbrhd.add_function(test1)

print(nbrhd.get_value('x'), nbrhd.params['x'].value)
# >>> 1 1
```