### PR TITLE
Adds option to pass list to Neighborhood

### DIFF
--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -40,11 +40,19 @@ class Neighborhood:
     _params: Dict[str, param.Param]
     _call_order: List[str]
 
-    def __init__(self):
+    def __init__(self, initial_doors: List[Callable] = []):
         """Initializes the Neighborhood object."""
         self._doors = {}
         self._params = {}
         self._call_order = []
+
+        for d in initial_doors:
+            if isinstance(d, door.BaseDoor):
+                self.add_door(d)
+
+            else:
+                self.add_function(d)
+
 
     def __repr__(self):
         """Must communicate teh following:

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -24,6 +24,7 @@ class TestNeighborhood(TestCase):
         def test1(x):
             pass
 
+        @door.Door
         def test2(y: int) -> int:
             z = y + 10
             return z

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -1,5 +1,5 @@
 import porchlight
-from porchlight import Neighborhood, Door, Param
+from porchlight import Neighborhood, Door, Param, door
 
 import unittest
 from unittest import TestCase
@@ -13,12 +13,24 @@ logging.basicConfig(filename=f"{os.getcwd()}/porchlight_unittest.log")
 
 class TestNeighborhood(TestCase):
     def test___init___(self):
-        # Initialization should not do anything beyond defining the empty
+        # Plain initialization should not do anything beyond defining the empty
         # Neighborhood._doors and Neighborhood._params attrs
         neighborhood = Neighborhood()
 
         self.assertEqual(neighborhood._doors, {})
         self.assertEqual(neighborhood._params, {})
+
+    def test___init___with_list(self):
+        def test1(x):
+            pass
+
+        def test2(y: int) -> int:
+            z = y + 10
+            return z
+
+        neighborhood = Neighborhood([test1, test2])
+
+        self.assertEqual(list(neighborhood.params.keys()), ['x', 'y', 'z'])
 
     def test___repr__(self):
         neighborhood = Neighborhood()


### PR DESCRIPTION
Adds a few lines to `porchlight.neighborhood.__init__` to handle a new kwarg, `initial_doors`, which is a list of `Door`/function objects.

These can be mixed! They do not all have to be doors or all have to be functions, it just iterated through the list and uses `add_door` and `add_function` methods depending on the object.