### PR TITLE
Adding NotImplementedError for uninspectable callables

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -185,7 +185,11 @@ class BaseDoor:
         if not self._can_inspect(function):
             msg = (
                 f"Function {self.name} could not be inspected and is not "
-                f"yet supported."
+                f"yet supported. You should wrap the function within a "
+                f"user-defined function, something like:\n\n"
+                f"    def new_func(arg1, arg2, ..., kwarg1, kwarg2, ... ): \n"
+                f"        output1, output2, ... = YOUR_FUNC(...)\n"
+                f"        return output1, output2, ...\n\n"
             )
 
             logger.error(msg)
@@ -285,7 +289,7 @@ class BaseDoor:
         except ValueError as e:
             logger.info(
                 f"Function {f.__name__} is not inspectable! "
-                f"{type(e).name}: {e}."
+                f"{type(e).__name__}: {e}."
             )
 
             return False

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -87,6 +87,34 @@ class TestBaseDoor(TestCase):
 
         self.assertEqual(result, 10)
 
+    def test_numpy_ufunc(self):
+        try:
+            import numpy as np
+
+        except ModuleNotFoundError as e:
+            # Printing a message and returning
+            print(
+                f"NOTICE: Could not run test {self.id()}, got "
+                f"ModuleNotFoundError: {e}."
+            )
+
+            return
+
+        # Test a subset of the available ufuncs.
+        tests = {
+            "log10": np.log10,
+            "log": np.log,
+            "sin": np.sin,
+            "greater": np.greater,
+        }
+
+        # Right now, this should throw NotImplementedErrors
+        expected = {n: NotImplementedError for n in tests}
+
+        for test, ufunc in tests.items():
+            with self.assertRaises(expected[test]):
+                BaseDoor(ufunc)
+
     def test___call__(self):
         def test_fxn(x: int) -> int:
             y = 2 * x


### PR DESCRIPTION
There are plenty of `Callables` in Python not yet supported in `porchlight` (e.g., `lambda`, `ufunc`). Before, this would raise a pretty scary error from inspect that is initially confusing. This adds a new error that is raised when `inspect.signature` cannot be generated using a `staticmethod` for `BaseDoor`.

### Examples
```python
import numpy as np
from porchlight import Door

try:
    Door(np.cos)

except NotImplementedError as e:
    print(f"NotImplementedError raised with message: {e}")
```
which prints:
```console
NotImplementedError raised with message: Function cos could not be inspected and is not yet supported. You should wrap the function within a user-defined function, something like:

    def new_func(arg1, arg2, ..., kwarg1, kwarg2, ... ):
        output1, output2, ... = YOUR_FUNC(...)
        return output1, output2, ...
```