### PR TITLE
Add an auto wrapper for non func callables and fix typechecking for `Door` objects

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -111,6 +111,15 @@ class BaseDoor:
             Note, this is not the same as a DynamicDoor, and internal
             variables/updating is not handled as with a DynamicDoor. This just
             calls Door's initializer on the output of the base function.
+
+        source : `str`, optional
+            If a non-empty string is provided, it will be parsed as source.
+            This is used to avoid using :py:meth:`inspect.getsourcelines()`.
+            This is primarily used by :py:class:`~porchlight.door.Door` for
+            wrapping special functions. Writing source directly is always
+            preferable.
+
+            Any str passed to this is safe; the source will never be executed.
         """
         self._returned_def_to_door = returned_def_to_door
         self._base_function = function
@@ -421,15 +430,120 @@ class Door(BaseDoor):
     """Inherits from and extends :class:`~porchlight.door.BaseDoor`"""
 
     def __init__(
-        self, function: Callable = None, *, argument_mapping: dict = {}
+        self,
+        function: Callable = None,
+        *,
+        argument_mapping: dict = {},
+        wrapped: bool = False,
+        arguments: dict = {},
+        keyword_args: dict = {},
+        return_vals: List = [],
+        name: str = "",
+        typecheck: bool = False,
     ):
+        """Initializes the :py:class:`~porchlight.door.Door` object using a
+        callable.
+
+        Arguments
+        ---------
+
+        function : Callable
+            A callable object to be parsed by :py:class:`~BaseDoor`.
+
+        argument_mapping : dict, keyword-only, optional
+            Maps parameters automatically by name. For example, to have a Door
+            accept "a" and "b" ans arguments instead of "x" and "y", one could
+            use
+
+            .. code-block:: python
+
+                def fxn(x):
+                    y = 2 * x
+                    return y
+
+                my_door = Door(fxn, argument_mapping={'x': 'a', 'y': 'b'})
+
+            to accomplish what would otherwise require wrapping the function
+            yourself.
+
+        wrapped : bool, keyword-only, optional
+            If `True`, will not parse the function using
+            :py:class:`~porchlight.door.BaseDoor`. Instead, it will take user
+            arguments and generate a function wrapper using the following
+            keyword-only arguments:
+
+                - arguments
+                - keyword_args
+                - return_vals
+
+            And this wrapper will be used to initialize the
+            :py:class:`~porchlight.door.BaseDoor` properties.
+
+        arguments : dict, keyword-only, optional
+            Arguments to be passed to the function if it is wrapped. Does not
+            override :py:class:`~porchlight.door.BaseDoor` if ``wrapped`` is
+            ``False``.
+
+        keyword_args : dict, keyword-only, optional
+            Corresponds to keyword arguments that may be passed positionally.
+            Only used when ``wrapped`` is ``True``.
+
+        name : str, keyword-only, optional
+            Overrides the default name for the Door if provided.
+
+        typecheck : :py:obj:`bool`, optional
+            If `True`, the `Door` object will assert that arguments passed
+            to `__call__` (when the `Door` itself is called like a
+            function) have the type expected by type annotations and any user
+            specifications. By default, this is `True`.
+        """
         self.argmap = argument_mapping
+        self.name = name
+        self.wrapped = wrapped
+        self.typecheck = typecheck
+
+        if name:
+            self.__name__ = name
+
+        # For wrapped functions, circumvent normal initialization.
+        if self.wrapped:
+            self._initialize_wrapped_function(
+                arguments, keyword_args, return_vals
+            )
+
+            # In these cases, there's no reason to use a decorator.
+            if function is None:
+                msg = "Auto-wrapped functions must be passed directly."
+
+                logger.error(msg)
+                raise DoorError(msg)
+
+            self._base_function = function
+
+            return
 
         self.function_initialized = False
         if function is None:
             return
 
         self.__call__(function)
+
+    def _initialize_wrapped_function(
+        self, arguments, keyword_args, return_vals
+    ):
+        """Initializes a function that is auto-wrapped by
+        :py:class:`~porchlight.door.Door` instead of being passed to
+        :py:class:`~porchlight.door.BaseDoor`
+        """
+        if not self.name:
+            self.name = "AutoWrappedFunctionDoor"
+            self.__name__ = self.name
+
+        self.arguments = arguments
+        self.keyword_args = keyword_args
+        self.return_vals = return_vals
+
+        self.function_initialized = True
 
     def __call__(self, *args, **kwargs):
         if not self.function_initialized:
@@ -449,13 +563,19 @@ class Door(BaseDoor):
                 raise TypeError(msg)
 
             function = args[0]
-            super().__init__(function)
+
+            super().__init__(function, typecheck=self.typecheck)
+
             self.function_initialized = True
 
             # Perform any necessary argument mapping.
             self.map_arguments()
 
             return self
+
+        if self.wrapped:
+            result = self._base_function(*args, **kwargs)
+            return result
 
         # Check argument mappings.
         if not self.argmap:

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -111,15 +111,6 @@ class BaseDoor:
             Note, this is not the same as a DynamicDoor, and internal
             variables/updating is not handled as with a DynamicDoor. This just
             calls Door's initializer on the output of the base function.
-
-        source : `str`, optional
-            If a non-empty string is provided, it will be parsed as source.
-            This is used to avoid using :py:meth:`inspect.getsourcelines()`.
-            This is primarily used by :py:class:`~porchlight.door.Door` for
-            wrapping special functions. Writing source directly is always
-            preferable.
-
-            Any str passed to this is safe; the source will never be executed.
         """
         self._returned_def_to_door = returned_def_to_door
         self._base_function = function

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -10,6 +10,7 @@ from porchlight.param import Empty, Param, ParameterError
 import typing
 import logging
 import os
+import math
 
 logging.basicConfig(filename=f"{os.getcwd()}/porchlight_unittest.log")
 
@@ -59,11 +60,19 @@ class TestDoor(TestCase):
             y = 2 * x
             return y
 
-        door = Door(test_fxn)
+        door = Door(test_fxn, typecheck=True)
 
         # Call the Door with erroneous types based on annotations.
         with self.assertRaises(ParameterError):
             door(x="6")
+
+        # Typechecking off
+        door = Door(test_fxn, typecheck=False)
+        door(x="6")
+
+        # Default functionality should be typechecking off
+        door = Door(test_fxn)
+        door(x=[6])
 
     def test_required_arguments(self):
         # This property is critical for the functioning of the Neighborhood
@@ -314,6 +323,37 @@ class TestDoor(TestCase):
 
         # Changing the argument mapping with the setter.
         test1.argument_mapping = {"hello_again": "x", "world_two": "z"}
+
+    # @unittest.skip("Because")
+    def test_auto_wrapping(self):
+        # Should work for any type of callable.
+        def my_func(x: int) -> int:
+            y = x + 1
+            return y
+
+        tests = [
+            (
+                my_func,
+                {"arguments": {"hello": int}, "return_vals": ["world"]},
+            ),
+            (
+                lambda x: x + 1,
+                {"arguments": {"x": int}, "return_vals": ["y"]},
+            ),
+            (
+                math.cos,
+                {
+                    "arguments": {"theta": int},
+                    "return_vals": ["cos_theta"],
+                },
+            ),
+        ]
+
+        for fxn, kwargs in tests:
+            my_door = Door(fxn, wrapped=True, **kwargs)
+
+            for arg, value in kwargs.items():
+                self.assertEqual(getattr(my_door, arg), value)
 
 
 if __name__ == "__main__":

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -11,6 +11,7 @@ import typing
 import logging
 import os
 import math
+import random
 
 logging.basicConfig(filename=f"{os.getcwd()}/porchlight_unittest.log")
 
@@ -324,7 +325,6 @@ class TestDoor(TestCase):
         # Changing the argument mapping with the setter.
         test1.argument_mapping = {"hello_again": "x", "world_two": "z"}
 
-    # @unittest.skip("Because")
     def test_auto_wrapping(self):
         # Should work for any type of callable.
         def my_func(x: int) -> int:
@@ -354,6 +354,30 @@ class TestDoor(TestCase):
 
             for arg, value in kwargs.items():
                 self.assertEqual(getattr(my_door, arg), value)
+
+        # Actually run the Door
+        my_door = Door(my_func, wrapped=True, **tests[0][1])
+        expected_output = [my_func(x) for x in range(10)]
+        output = [my_door(x) for x in range(10)]
+
+        self.assertEqual(expected_output, output)
+
+        # Test a slightly more complicated door.
+        def test1(x: int, *, y=0) -> int:
+            z = x ** y
+            return z
+
+        kwargs = {
+            "arguments": {"x": int},
+            "keyword_args": {"y": 0},
+            "return_vals": ["z"],
+        }
+
+        normal_door = Door(test1)
+        wrapped_door = Door(test1, wrapped=True, **kwargs)
+
+        self.assertEqual(normal_door(5), wrapped_door(5))
+        self.assertEqual(normal_door(-500, y=2), wrapped_door(-500, y=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR to the new `v0.4.0` branch makes several major changes to the existing code:

1. `typecheck` via `Door` is now supported in all cases save for auto-wrapping (see point 2)
2. "Auto-wrapping" is now supported by `Door`, which is a very inelegant (but functional) solution to issue #49.
3. Testing update to fix breaks caused by point 1.

Although the functionality that was previously broken isn't incredibly impactful on most cases, this is not strictly compatible with previous versions.

This PR being accepted resolves and closes Issue #49.