### PR TITLE
Return values and argument mapping

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -619,13 +619,16 @@ class Door(BaseDoor):
                     logger.error(msg)
                     raise DoorError(msg)
 
-                if old_name not in self.arguments:
+                if old_name not in self.arguments and not any(
+                    old_name in retvals for retvals in self.return_vals
+                ):
                     msg = f"{old_name} is not a valid argument for {self.name}"
                     logger.error(msg)
                     raise DoorError(msg)
 
-                self.arguments[mapped_name] = self.arguments[old_name]
-                del self.arguments[old_name]
+                if old_name in self.arguments:
+                    self.arguments[mapped_name] = self.arguments[old_name]
+                    del self.arguments[old_name]
 
                 # Change keyword arguments as well.
                 if old_name in self.keyword_args:

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -325,6 +325,28 @@ class TestDoor(TestCase):
         # Changing the argument mapping with the setter.
         test1.argument_mapping = {"hello_again": "x", "world_two": "z"}
 
+    def test_argument_mapping_return_values(self):
+        # Below works as expected. The return value is visible as 'why'.
+        @Door(argument_mapping={"ecks": "x", "why": "y"})
+        def test1(x, y):
+            y = x + 1
+            return y
+
+        # This raises a DoorError
+        @Door(argument_mapping={"ecks": "x", "why": "y"})
+        def test2(x):
+            y = x + 1
+            return y
+
+        # These tests should work exactly the same in terms of input/output.
+        def testval():
+            return random.randint(-10, 10)
+
+        tests = [[testval(), testval()] for _ in range(100)]
+
+        for x, y in tests:
+            self.assertEqual(test1(x, y), test2(x))
+
     def test_auto_wrapping(self):
         # Should work for any type of callable.
         def my_func(x: int) -> int:


### PR DESCRIPTION
`Door.map_arguments` will now handle parameter names that are in return values but *not* in the arugment list. This PR closes issue #50.