### PR TITLE
Finalize how ambiguous return values will be handled

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help porchlight improve
+title: "[BUG]"
+labels: bug, help wanted, question
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior (a code snippet preferred):
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Specs (please complete the following information):**
+ - OS: [e.g. Windows]
+ - Python version: [e.g., 3.7.1]
+ - Version [e.g. v0.1.0]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/help-request.md
+++ b/.github/ISSUE_TEMPLATE/help-request.md
@@ -1,0 +1,21 @@
+---
+name: Help request
+about: Submit a question you have about using porchlight.
+title: ''
+labels: help wanted, question
+assignees: ''
+
+---
+
+**Describe your question or situation succinctly (1-2 sentences)**
+[your words here]
+
+**Describe your situation in appropriate detail, if needed**
+Tips:
+    + Include code snippets if you have any.
+    + *emphasize* things that you think are important to understanding the situation.
+
+**Specs (please provide if asking for any help with code**
+OS: [e.g., Windows 10]
+Python: [e.g., 3.9.4]
+`porchlight`: [e.g., v0.1.0]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Welcome to |porchlight|'s documentation!
 coupling Python functions and managing shared data.
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Contents:
 
    other/about

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -365,6 +365,7 @@ class BaseDoor:
         # definition.
         defmatch_str = r"^(\ )+def\s+"
         retmatch_str = r".*\s+return\s(.*)"
+        retmatch_str = r"^\s+(?:return|yield)\s(.*)"
         indentmatch_str = r"^(\s)*"
 
         for i, line in enumerate(lines):

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -43,12 +43,6 @@ class BaseDoor:
         arguments without a default value are assigned a
         :class:~porchlight.param.Empty` value instead of their default value.
 
-    max_n_return : :py:obj:`int`
-        Maximum number of returned values.
-
-    min_n_return : :py:obj:`int`
-        Minimum number of returned values.
-
     n_args : :py:obj:`int`
         Number of arguments accepted by this `BaseDoor`
 
@@ -85,8 +79,6 @@ class BaseDoor:
     _base_function: Callable
     arguments: Dict[str, Type]
     keyword_args: Dict[str, Any]
-    max_n_return: int
-    min_n_return: int
     n_args: int
     name: str
     return_types: List[Type]

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -55,11 +55,22 @@ class BaseDoor:
     name : :py:obj:`str`
         The name of the function as visible from the base function's __name__.
 
-    return_types : :py:obj:`list` of :py:obj:`list` of `~typing.Type`
+    return_types : :py:obj:`dict` of :py:obj:`str`, :py:obj:`Type` pairs.
         Values returned by any return statements in the base function.
 
-    return_vals : :py:obj:`list` of :py:obj:`list` of :py:obj:`str`
-        Values returned by any return statements in the base function.
+    return_vals : :py:obj:`list` of :py:obj:`str`
+        Names of parameters returned by the base function. Any return
+        statements in a Door much haveidentical return parameters. I.e., the
+        following would fail if imported as a Door.
+
+        .. code-block:: python
+
+           def fxn(x):
+               if x < 1:
+                   y = x + 1
+                   return x, y
+
+               return x
 
     typecheck : :py:obj:`bool`
         If True, when arguments are passed to the `BaseDoor`'s base function
@@ -78,7 +89,7 @@ class BaseDoor:
     min_n_return: int
     n_args: int
     name: str
-    return_types: List[List[Type]]
+    return_types: List[Type]
     return_vals: List[List[str]]
     typecheck: bool
 
@@ -156,6 +167,8 @@ class BaseDoor:
         self.keyword_args = {}
         self.keyword_only_args = {}
 
+        # Attempting to retrieve type hints for the return value. This *does
+        # not* fail if they aren't found.
         try:
             ret_type_annotation = typing.get_type_hints(function)["return"]
             self.return_types = decompose_type(

--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -679,10 +679,10 @@ class Door(BaseDoor):
                     del self.keyword_args[old_name]
 
                 # Also change outputs that contain the same name.
-                for i, ret_tuple in enumerate(self.return_vals):
-                    for j, ret_val in enumerate(ret_tuple):
-                        if old_name == ret_val:
-                            self.return_vals[i][j] = mapped_name
+                ret_tuple = self.return_vals
+                for i, ret_val in enumerate(ret_tuple):
+                    if old_name == ret_val:
+                        self.return_vals[i] = mapped_name
 
             # Place back in the original order.
             rev_argmap = {v: k for k, v in self.argmap.items()}
@@ -747,10 +747,9 @@ class Door(BaseDoor):
         return_vals = copy.copy(self.return_vals)
 
         # Also change outputs that contain the same name.
-        for i, ret_tuple in enumerate(self.return_vals):
-            for j, ret_val in enumerate(ret_tuple):
-                if ret_val in self.argmap:
-                    return_vals[i][j] = self.argmap[ret_val]
+        for i, ret_val in enumerate(return_vals):
+            if ret_val in self.argmap:
+                return_vals[i] = self.argmap[ret_val]
 
         return return_vals
 
@@ -775,9 +774,8 @@ class Door(BaseDoor):
                 all_vars.append(arg)
 
         for ret in self.return_vals:
-            for r in ret:
-                if r not in all_vars:
-                    all_vars.append(r)
+            if ret not in all_vars:
+                all_vars.append(ret)
 
         return all_vars
 

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -53,7 +53,6 @@ class Neighborhood:
             else:
                 self.add_function(d)
 
-
     def __repr__(self):
         """Must communicate teh following:
         + A unique identifier.
@@ -115,9 +114,9 @@ class Neighborhood:
             :class:`~porchlight.door.DynamicDoor`, or :py:obj:`list` of
             :class:`~porchlight.door.Door` objects.
 
-            Either a single initialized
-            `door.Door` object or a list of them.  If a list is provided, this
-            function is called for each item in the list.
+            Either a single initialized `door.Door` object or a list of them.
+            If a list is provided, this function is called for each item in the
+            list.
 
         overwrite_defaults : bool, optional
             If `True`, will overwrite any parameters shared between the

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -408,6 +408,30 @@ class TestBaseDoor(TestCase):
         for attr, val in expected.items():
             self.assertEqual(getattr(testgen1, attr), val)
 
+        # Should be identical to something with return instead of yield (for
+        # porchlight specifically).
+        @BaseDoor
+        def test1(x):
+            y = 0
+
+            while y <= x:
+                return y
+                y = y + 1
+
+            return y
+
+        test_attrs = [
+            "arguments",
+            "positional_only",
+            "keyword_args",
+            "n_args",
+            "return_types",
+            "return_vals",
+        ]
+
+        for attr in test_attrs:
+            self.assertEqual(getattr(test1, attr), getattr(testgen1, attr))
+
 
 if __name__ == "__main__":
     import unittest

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -24,7 +24,7 @@ class TestBaseDoor(TestCase):
         # Must contain both input and output parameter.
         arguments = ["x"]
         keyword_args = ["x"]
-        return_vals = [["y"]]
+        return_vals = ["y"]
 
         # Not comparing any values during this test.
         for arg in arguments:
@@ -70,7 +70,7 @@ class TestBaseDoor(TestCase):
         # Must contain both input and output parameter.
         arguments = ["x"]
         keyword_args = ["x"]
-        return_vals = [["y"]]
+        return_vals = ["y"]
 
         # Not comparing any values during this test.
         for arg in arguments:
@@ -79,8 +79,7 @@ class TestBaseDoor(TestCase):
         for kwarg in keyword_args:
             self.assertIn(kwarg, door.keyword_args)
 
-        for retval in return_vals:
-            self.assertIn(retval, door.return_vals)
+        self.assertEqual(return_vals, door.return_vals)
 
         # Call the BaseDoor
         result = door(x=5)
@@ -93,7 +92,7 @@ class TestBaseDoor(TestCase):
 
         except ModuleNotFoundError as e:
             # Printing a message and returning
-            print(
+            logging.error(
                 f"NOTICE: Could not run test {self.id()}, got "
                 f"ModuleNotFoundError: {e}."
             )
@@ -311,7 +310,7 @@ class TestBaseDoor(TestCase):
         expected_repr = (
             f"BaseDoor(name=test, base_function={str(test)}, "
             f"arguments={{'x': <class 'int'>}}, "
-            f"return_vals=[['y']])"
+            f"return_vals=['y'])"
         )
 
         test_door = BaseDoor(test)

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -391,6 +391,23 @@ class TestBaseDoor(TestCase):
 
         self.assertEqual(test_prop.kwargs, expected_val)
 
+    def test_generator(self):
+        # Tests generator functions with porchlight.
+        @BaseDoor
+        def testgen1(x):
+            y = 0
+
+            while y <= x:
+                yield y
+                y = y + 1
+
+            return y
+
+        expected = {"arguments": {"x": Empty()}, "return_vals": ["y"]}
+
+        for attr, val in expected.items():
+            self.assertEqual(getattr(testgen1, attr), val)
+
 
 if __name__ == "__main__":
     import unittest

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -27,7 +27,7 @@ class TestDoor(TestCase):
         # Must contain both input and output parameter.
         arguments = ["x"]
         keyword_args = ["x"]
-        return_vals = [["y"]]
+        return_vals = ["y"]
 
         # Not comparing any values during this test.
         for arg in arguments:
@@ -36,8 +36,7 @@ class TestDoor(TestCase):
         for kwarg in keyword_args:
             self.assertIn(kwarg, door.keyword_args)
 
-        for retval in return_vals:
-            self.assertIn(retval, door.return_vals)
+        self.assertEqual(return_vals, door.return_vals)
 
         # Call the Door
         result = door(x=5)
@@ -158,7 +157,7 @@ class TestDoor(TestCase):
         expected_repr = (
             f"Door(name=test, base_function={str(test)}, "
             f"arguments={{'x': <class 'int'>}}, "
-            f"return_vals=[['y']])"
+            f"return_vals=['y'])"
         )
 
         test_door = Door(test)
@@ -178,7 +177,7 @@ class TestDoor(TestCase):
             return z, x
 
         self.assertEqual(my_func.variables, ["hello", "world", "z"])
-        self.assertEqual(my_func.return_vals, [["z", "hello"]])
+        self.assertEqual(my_func.return_vals, ["z", "hello"])
         self.assertEqual(my_func.required_arguments, ["hello"])
         self.assertEqual(my_func.original_arguments, orig_func.arguments)
         self.assertEqual(my_func.original_return_vals, orig_func.return_vals)
@@ -206,7 +205,7 @@ class TestDoor(TestCase):
             test2_mapped.variables,
             ["temperature", "pressure", "k_B", "density"],
         )
-        self.assertEqual(test2_mapped.return_vals, [["density"]])
+        self.assertEqual(test2_mapped.return_vals, ["density"])
         self.assertEqual(test2_mapped.required_arguments, [])
         self.assertEqual(
             test2_mapped.original_arguments, test2_unmapped.arguments
@@ -231,30 +230,17 @@ class TestDoor(TestCase):
         self.assertEqual(list(test4.arguments.keys()), ["x"])
 
     def test_mapping_multiple_returns(self):
-        @Door(argument_mapping={"hello": "x", "bing": "z"})
-        def test1(x, y: int, z=1) -> typing.Tuple[int]:
-            result = True if x < y else False
+        with self.assertRaises(DoorError):
 
-            if result:
-                return result, x, z
+            @Door(argument_mapping={"hello": "x", "bing": "z"})
+            def test1(x, y: int, z=1) -> typing.Tuple[int]:
+                result = True if x < y else False
 
-            else:
-                return result, y, z
+                if result:
+                    return result, x, z
 
-        self.maxDiff = None
-        self.assertEqual(
-            test1.return_vals,
-            [["result", "hello", "bing"], ["result", "y", "bing"]],
-        )
-        self.assertEqual(list(test1.arguments.keys()), ["hello", "y", "bing"])
-        self.assertEqual(
-            test1.keyword_arguments,
-            {
-                "hello": Param("hello"),
-                "y": Param("y"),
-                "bing": Param("bing", 1),
-            },
-        )
+                else:
+                    return result, y, z
 
     def test_bad_mapping_variable_names(self):
         bad_names = ("0fign_", " bonk", "this is a sentence...", "there.dot")

--- a/porchlight/tests/test_dynamicdoor.py
+++ b/porchlight/tests/test_dynamicdoor.py
@@ -95,7 +95,7 @@ class TestDynamicDoor(unittest.TestCase):
 
         self.assertEqual(doorgen1(2, 5), 2 ** 5)
         self.assertEqual(doorgen1.arguments, {"hello": int, "y": int})
-        self.assertEqual(doorgen1.return_vals, [["z"]])
+        self.assertEqual(doorgen1.return_vals, ["z"])
 
         @door.Door(argument_mapping={"hello": "x"})
         def doorgen2(x: int, y: int = 1) -> door.Door:

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -176,10 +176,6 @@ class TestNeighborhood(TestCase):
 
         neighborhood.add_door([test1, test2, test3, test4])
 
-        import pytest
-
-        pytest.set_trace()
-
         self.assertEqual(len(neighborhood._doors), 4)
         self.assertEqual(len(neighborhood._params), 4)
 

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -31,7 +31,7 @@ class TestNeighborhood(TestCase):
 
         neighborhood = Neighborhood([test1, test2])
 
-        self.assertEqual(list(neighborhood.params.keys()), ['x', 'y', 'z'])
+        self.assertEqual(list(neighborhood.params.keys()), ["x", "y", "z"])
 
     def test___repr__(self):
         neighborhood = Neighborhood()
@@ -175,6 +175,10 @@ class TestNeighborhood(TestCase):
         neighborhood = Neighborhood()
 
         neighborhood.add_door([test1, test2, test3, test4])
+
+        import pytest
+
+        pytest.set_trace()
 
         self.assertEqual(len(neighborhood._doors), 4)
         self.assertEqual(len(neighborhood._params), 4)


### PR DESCRIPTION
Closes issue #19 upon merging into `main`.

This PR updates `porchlight` to require strict return value formats for all `def`s. It also includes (bare minimum) support for `yield` statements, although this does not change any porchlight behavior outside of what goes into `BaseDoor.return_vals`.