### PR TITLE
21 singleton empty

### DIFF
--- a/porchlight/door.py
+++ b/porchlight/door.py
@@ -229,7 +229,7 @@ class BaseDoor:
 
         for name, _type in self.arguments.items():
             if _type == inspect._empty:
-                self.arguments[name] = Empty
+                self.arguments[name] = Empty()
 
         self.n_args = len(self.arguments)
 
@@ -262,7 +262,7 @@ class BaseDoor:
         # Type checking.
         if self.typecheck:
             for k, v in input_kwargs.items():
-                if self.arguments[k] == Empty:
+                if self.arguments[k] == Empty():
                     continue
 
                 if not isinstance(v, self.arguments[k]):
@@ -750,7 +750,7 @@ class Door(BaseDoor):
         required = []
 
         for x in self.arguments:
-            if isinstance(self.keyword_args[x].value, Empty):
+            if self.keyword_args[x].value == Empty():
                 required.append(x)
 
         return required

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -53,7 +53,6 @@ class Neighborhood:
             else:
                 self.add_function(d)
 
-
     def __repr__(self):
         """Must communicate teh following:
         + A unique identifier.
@@ -206,7 +205,7 @@ class Neighborhood:
                     template_ddoor.generator_kwargs = {"param_name": ret_val}
 
                     self.add_door(template_ddoor)
-                    self.add_param(ret_val, param.Empty)
+                    self.add_param(ret_val, param.Empty())
 
     def remove_door(self, name: str):
         """Removes a :class:`~porchlight.door.Door` from :attr:`_doors`.

--- a/porchlight/param.py
+++ b/porchlight/param.py
@@ -12,16 +12,21 @@ class ParameterError(Exception):
 
 
 class Empty:
-    """An empty class representing missing parameters values."""
+    """An empty class representing missing parameters values.
 
-    def __init__(self):
-        pass
+    At initializtion, if an instance does not already exist it is created.
+    """
+
+    def __new__(cls):
+        # Return the singleton instance if it exists already, otherwise become
+        # the singleton instance.
+        if not hasattr(cls, "_singleton_instance"):
+            cls._singleton_instance = super(Empty, cls).__new__(cls)
+
+        return cls._singleton_instance
 
     def __eq__(self, other):
-        """Force Equality of this special value regardless of whether it is
-        initialized or not.
-        """
-        if isinstance(other, Empty) or other == Empty:
+        if other is self:
             return True
 
         else:

--- a/porchlight/tests/test_basedoor.py
+++ b/porchlight/tests/test_basedoor.py
@@ -51,7 +51,7 @@ class TestBaseDoor(TestCase):
 
         self.assertEqual(fxn_use_decorator.name, "fxn_use_decorator")
 
-        self.assertEqual(fxn_use_decorator.arguments, {"x": Empty})
+        self.assertEqual(fxn_use_decorator.arguments, {"x": Empty()})
 
         # Test on a decorated function.
         def test_decorator(fxn):
@@ -339,7 +339,7 @@ class TestBaseDoor(TestCase):
             "pos2": Empty(),
             "kwpos": Empty(),
             "kwposdef": Empty(),
-            "kwonly": Empty,
+            "kwonly": Empty(),
         }
 
         self.assertEqual(new_door.arguments, expected_arguments)

--- a/porchlight/tests/test_door.py
+++ b/porchlight/tests/test_door.py
@@ -54,7 +54,7 @@ class TestDoor(TestCase):
 
         self.assertEqual(fxn_use_decorator.name, "fxn_use_decorator")
 
-        self.assertEqual(fxn_use_decorator.arguments, {"x": Empty})
+        self.assertEqual(fxn_use_decorator.arguments, {"x": Empty()})
 
     def test___call__(self):
         def test_fxn(x: int) -> int:
@@ -281,7 +281,9 @@ class TestDoor(TestCase):
 
         test2 = Door(test1)
 
-        self.assertEqual(test2.arguments, {"x": Empty, "y": int, "z": Empty})
+        self.assertEqual(
+            test2.arguments, {"x": Empty(), "y": int, "z": Empty()}
+        )
 
     def test_bad_mapping_bad_functions(self):
         # A bad argument

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -31,7 +31,7 @@ class TestNeighborhood(TestCase):
 
         neighborhood = Neighborhood([test1, test2])
 
-        self.assertEqual(list(neighborhood.params.keys()), ['x', 'y', 'z'])
+        self.assertEqual(list(neighborhood.params.keys()), ["x", "y", "z"])
 
     def test___repr__(self):
         neighborhood = Neighborhood()
@@ -48,15 +48,15 @@ class TestNeighborhood(TestCase):
         # Keeping the below as an example of what the string looks like. Update
         # this to match the actual implementation as changes occur below.
         # expected = (
-        #     "Neighborhood(doors={'test1': Door(name=test1, "
-        #     "base_function=<function test1 at 0x7f247d8c48b0>, "
-        #     "arguments={'x': <class 'int'>}, return_vals=[['y']])}, "
-        #     "params={'x': Param(name=x, value=<porchlight.param."
-        #     "Empty object at 0x7f247e1bd060>, constant=False, type=<class "
-        #     "'porchlight.param.Empty'>), 'y': Param(name="
-        #     "y, value=<porchlight.param.Empty object at 0x7f247d8c9660>, "
-        #     "constant=False, type=<class 'porchlight.param "
-        #     ".Empty'>)}, call_order=['test1'])"
+        #     Neighborhood(doors={'test1': Door(name=test1,
+        #     base_function=<function TestNeighborhood.test___repr__.<lo
+        #     cals>.test1 at 0x7fdcf1333640>, arguments={'x': <class 'int'>},
+        #     return_vals=[['y']])}, params={'x': Para m(name=x,
+        #     value=<porchlight.param.Empty object at 0x7fdcf127f1f0>,
+        #     constant=False, type=<class 'porchlig ht.param.Empty'>), 'y':
+        #     Param(name=y, value=<porchlight.param.Empty object at
+        #     0x7fdcf127f1f0>, constant= False, type=<class
+        #     'porchlight.param.Empty'>)}, call_order=['test1'])
         # )
 
         params = neighborhood.params

--- a/porchlight/tests/test_param.py
+++ b/porchlight/tests/test_param.py
@@ -103,8 +103,7 @@ class TestEmpty(TestCase):
     def test___eq__(self):
         empty = param.Empty()
 
-        self.assertTrue(empty, param.Empty)
-        self.assertTrue(empty, param.Empty())
+        self.assertEqual(empty, param.Empty())
         self.assertNotEqual(empty, 1)
 
 


### PR DESCRIPTION
This makes `porchlight.param.Empty` a singleton, so that only one instance of it exists at any given time.

This is not backwards-compatible, as previously `param.Empty == param.Empty()` evaluated to `True`, but will now evaluate to `False`. Only `param.Empty() == param.Empty()` is valid, now, and is exactly equivalent to `param.Empty() is param.Empty()`.

When pulled into `main`, this closes issue #21.