### PR TITLE
Remove print statement from unit test, add docstring

### DIFF
--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -667,6 +667,11 @@ class Neighborhood:
                     self.add_param(retval, value, constant=True)
 
     def run_steps(self, number_of_steps: int):
+        """This function calls :py:meth:`~porchlight.Neighborhood.run_step`
+        repeatedly.
+
+        It is exactly equivalent to the following code:
+        """
         if not isinstance(number_of_steps, int):
             number_of_steps = int(number_of_steps)
 

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -736,11 +736,6 @@ class TestNeighborhood(TestCase):
             x += 1
             y *= 2
             z = x + y
-            print("Testing finalization and values are:")
-            print(f"\t{x = }")
-            print(f"\t{y = }")
-            print(f"\t{z = }")
-
             return x, y, z
 
         # This tests returns that are not tuples


### PR DESCRIPTION
This is a very minor fix to add a single docstring and remove print statements that interfere with the function of executing unit tests using the native python `unittest` model.