### PR TITLE
72 bug initialization with keyword argument not recognized as default value

### DIFF
--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -614,7 +614,10 @@ class Neighborhood:
             if not isinstance(fxn, door.Door):
                 fxn = door.Door(fxn)
 
-            defaults = fxn.keyword_args
+            empty = param.Empty()
+            defaults = {
+                k: v for k, v in fxn.keyword_args.items() if v.value != empty
+            }
 
             return_values = fxn.return_vals
             arguments, keyword_arguments = self.gather_door_arguments(

--- a/porchlight/neighborhood.py
+++ b/porchlight/neighborhood.py
@@ -34,7 +34,7 @@ class Neighborhood:
         `_doors` are called. By default, this is the order in which
         :class:`~porchlight.door.Door`s are added to the `Neighborhood`.
 
-    _initialization : :py:obj:`list` of ``Callable``, `keyword-only`
+    initialization : :py:obj:`list` of ``Callable``, `keyword-only`
         These will be called once the
         :class:`~porchlight.neighborhood.Neighborhood` object begins any
         execution (e.g., via
@@ -527,7 +527,9 @@ class Neighborhood:
         # call.
         return output
 
-    def gather_door_arguments(self, input_door: door.Door) -> Tuple[List, Dict]:
+    def gather_door_arguments(
+        self, input_door: door.Door, defaults: Dict[str, Any] = {}
+    ) -> Tuple[List, Dict]:
         """This retrieves all parameters required by a
         :py:class:`~porchlight.door.Door`, returning them as a list (positional
         arguments) and a dictionary (keyword arguments). If there are no
@@ -538,6 +540,11 @@ class Neighborhood:
         ---------
         input_door : :py:class:`~porchlight.door.Door`
             The door to gather necessary parameters for.
+
+        defaults : dict[str, Any]
+            Default values for any arguments that may be missing from the
+            Neighborhood. Keys must correspond to an arg or kwarg present in
+            the input_door.
 
         Returns
         -------
@@ -552,9 +559,12 @@ class Neighborhood:
         The return values must be unpacked before being used to call the
         :py:class:`~porchlight.door.Door`.
         """
-        # Gather the arguments needed by the door.
+        # Gather the arguments needed by the door. Defaults are folded into a
+        # new dictionary to keep them temporary.
         req_params = input_door.arguments
-        input_params = {p: self._params[p].value for p in req_params}
+        known_params = defaults | self._params
+
+        input_params = {p: known_params[p].value for p in req_params}
 
         args = []
         kwargs = {}
@@ -604,8 +614,12 @@ class Neighborhood:
             if not isinstance(fxn, door.Door):
                 fxn = door.Door(fxn)
 
+            defaults = fxn.keyword_args
+
             return_values = fxn.return_vals
-            arguments, keyword_arguments = self.gather_door_arguments(fxn)
+            arguments, keyword_arguments = self.gather_door_arguments(
+                fxn, defaults=defaults
+            )
 
             result = fxn(*arguments, **keyword_arguments)
 
@@ -621,6 +635,9 @@ class Neighborhood:
             for retval, value in zip(return_values, result):
                 if retval in neighborhood_params:
                     self.set_param(retval, value)
+
+                else:
+                    self.add_param(retval, value)
 
     def finalize(self):
         """Finalization executes doors/callables found in

--- a/porchlight/param.py
+++ b/porchlight/param.py
@@ -32,6 +32,9 @@ class Empty:
         else:
             return False
 
+    def __neq__(self, other):
+        return not (self == other)
+
 
 class Param:
     """Parameter class. while not frozen, for most purposes it should not be

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -739,11 +739,35 @@ class TestNeighborhood(TestCase):
         def inittest2(kwarg=10):
             pass
 
-        neighborhood = Neighborhood(initialization=inittest2)
+        neighborhood_3 = Neighborhood(initialization=inittest2)
 
         # This should be able to execute, using the default argument from
         # inittest2.
-        neighborhood.run_step()
+        neighborhood_3.run_step()
+
+        # Test with a bad argument.
+        def inittest3(arg, kwarg=10):
+            # Arbitrary choice, just providing a return value that won't be
+            # picked up being the neighborhood.
+            return f"{arg}: {kwarg}"
+
+        def inittest4(arg, kwarg=12):
+            # Note: using a different kwarg default value here.
+            retval_needed = f"{kwarg}: {arg}"
+            return retval_needed
+
+        neighborhood_4 = Neighborhood(
+            initialization=[inittest1, inittest2, inittest3, inittest4]
+        )
+
+        neighborhood_4.add_param("retval_needed", None)
+
+        with self.assertRaises(KeyError):
+            neighborhood_4.run_step()
+
+        neighborhood_4.add_param("arg", "Hello world")
+
+        neighborhood_4.run_step()
 
     def test_plain_finalization(self):
         # Testing specifically a None-returning function.

--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -723,7 +723,6 @@ class TestNeighborhood(TestCase):
         self.assertEqual(neighborhood.get_value("x"), 5)
         self.assertEqual(neighborhood.get_value("y"), 25)
 
-    @unittest.skip(reason="Because")
     def test_plain_initialization(self):
         # Testing specifically a None-returning function.
         def inittest1():
@@ -734,6 +733,17 @@ class TestNeighborhood(TestCase):
 
         neighborhood_2 = Neighborhood([], initialization=[inittest1])
         neighborhood_2.run_step()
+
+        # Test keyword arguments --- test introduced in Issue #72 --
+        # Initialization with keyword argument not recognized as default value.
+        def inittest2(kwarg=10):
+            pass
+
+        neighborhood = Neighborhood(initialization=inittest2)
+
+        # This should be able to execute, using the default argument from
+        # inittest2.
+        neighborhood.run_step()
 
     def test_plain_finalization(self):
         # Testing specifically a None-returning function.


### PR DESCRIPTION
Closes Issue #72 by having initializers pass known keyword defaults to a newly reformatted `Neighborhood.get_door_arguments`, which accepts the keyword argument `defaults`. These defaults do not interfere with any existing parameters in the `Neighborhood` object, and are only used if a required value cannot be found in the parameter dictionary.