### PR TITLE
Adding warning assertion in neighborhood testing.

### DIFF
--- a/porchlight/tests/test_neighborhood.py
+++ b/porchlight/tests/test_neighborhood.py
@@ -756,18 +756,21 @@ class TestNeighborhood(TestCase):
             retval_needed = f"{kwarg}: {arg}"
             return retval_needed
 
+        # This warns the user about the invalid return argument that will be
+        # ignored.
         neighborhood_4 = Neighborhood(
             initialization=[inittest1, inittest2, inittest3, inittest4]
         )
 
         neighborhood_4.add_param("retval_needed", None)
 
-        with self.assertRaises(KeyError):
+        with self.assertWarns(door.DoorWarning), self.assertRaises(KeyError):
             neighborhood_4.run_step()
 
         neighborhood_4.add_param("arg", "Hello world")
 
-        neighborhood_4.run_step()
+        with self.assertWarns(door.DoorWarning):
+            neighborhood_4.run_step()
 
     def test_plain_finalization(self):
         # Testing specifically a None-returning function.


### PR DESCRIPTION
Suppresses a warning when running tests. The warning,  a `porchlight.door.DoorWarning`, *should* trigger, and so this adds a unit-testing context manager to ensure the warning is raised in the test.